### PR TITLE
Add support for basic, identifier, types to model and modelprinter

### DIFF
--- a/examples/ident_types_only/ident.go
+++ b/examples/ident_types_only/ident.go
@@ -1,5 +1,7 @@
 package ident
 
+type IdentPrim int
+
 type Ident struct {
 	String string
 
@@ -26,4 +28,6 @@ type Ident struct {
 	Complex128 complex128
 
 	Bool bool
+
+	IPrim IdentPrim
 }

--- a/src/gooptions/fields.go
+++ b/src/gooptions/fields.go
@@ -29,8 +29,7 @@ func CollectModelFieldsFromASTFieldList(fieldList *ast.FieldList) []*model.Field
 	result := make([]*model.Field, 0, len(fieldList.List))
 
 	for _, field := range fieldList.List {
-		modelField := NewModelFieldFromASTField(field)
-		if modelField != nil {
+		if modelField, ok := NewModelFieldFromASTField(field); ok {
 			result = append(result, modelField)
 		}
 	}
@@ -38,7 +37,7 @@ func CollectModelFieldsFromASTFieldList(fieldList *ast.FieldList) []*model.Field
 	return result
 }
 
-func NewModelFieldFromASTField(field *ast.Field) *model.Field {
+func NewModelFieldFromASTField(field *ast.Field) (*model.Field, bool) {
 	var modelFT model.FieldType
 
 	switch astFT := field.Type.(type) {
@@ -47,12 +46,13 @@ func NewModelFieldFromASTField(field *ast.Field) *model.Field {
 
 	default:
 		log.Printf("unsupported *ast.Field.Type %T", astFT)
+		return nil, false
 	}
 
 	return &model.Field{
 		Name: NameOfField(field),
 		Type: modelFT,
-	}
+	}, true
 }
 
 func NameOfField(field *ast.Field) string {

--- a/src/gooptions/fields.go
+++ b/src/gooptions/fields.go
@@ -1,7 +1,6 @@
 package gooptions
 
 import (
-	"fmt"
 	"go/ast"
 	"log"
 
@@ -9,11 +8,11 @@ import (
 )
 
 func addStructTypeToModel(m *model.Model, filePath, packageName, typeName string, structType *ast.StructType) error {
-	fmt.Println("addStructTypeToModel()", typeName, len(structType.Fields.List))
+	log.Println("addStructTypeToModel()", typeName, len(structType.Fields.List))
 
 	modelFields := CollectModelFieldsFromASTFieldList(structType.Fields)
 
-	fmt.Printf("%#v\n", modelFields)
+	log.Printf("%#v\n", modelFields)
 
 	tol := model.NewTypeOptionList(
 		filePath,

--- a/src/gooptions/gooptions.go
+++ b/src/gooptions/gooptions.go
@@ -7,6 +7,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -29,14 +30,14 @@ func GenerateOptionsModel(out io.Writer, path string) (*model.Model, error) {
 		return nil, err
 	}
 
-	fmt.Fprintln(out, "goFilePaths", goFilePaths)
+	log.Println(out, "goFilePaths", goFilePaths)
 
 	goFileASTs, err := ParseGoFileASTs(goFilePaths)
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Fprintln(out, "goFileASTs", goFileASTs)
+	log.Println(out, "goFileASTs", goFileASTs)
 
 	result := model.NewModel()
 

--- a/src/gooptions/model/modelprinter/generate.go
+++ b/src/gooptions/model/modelprinter/generate.go
@@ -30,7 +30,7 @@ func (g *Generator) Unindent() {
 	}
 }
 
-func (g *Generator) P(f string, args ...interface{}) {
+func (g *Generator) Fpln(f string, args ...interface{}) {
 	fmt.Fprintf(g.buffer, g.indent+f+"\n", args...)
 }
 
@@ -45,7 +45,7 @@ func GenTypeOptionLists(g *Generator /*config*/, tols []*model.TypeOptionList) {
 	GenPackage(g, tols)
 
 	for _, tol := range tols {
-		g.P("")
+		g.Fpln("")
 		GenTypeOptionList(g, tol)
 	}
 }
@@ -56,23 +56,34 @@ func GenDocComments(g *Generator, tols []*model.TypeOptionList) {
 
 func GenPackage(g *Generator, tols []*model.TypeOptionList) {
 	if len(tols) > 0 {
-		g.P("package %s", tols[0].PackageName)
+		g.Fpln("package %s", tols[0].PackageName)
 	}
 }
 
 func GenTypeOptionList(g *Generator, tol *model.TypeOptionList) {
 	GenOptionType(g, tol)
 
-	GenTypeOptionFactories(g, tol)
+	g.Fpln("")
+
+	GenTypeOptionFieldFactories(g, tol)
 }
 
 func GenOptionType(g *Generator, tol *model.TypeOptionList) {
-	g.P("type Option func(*%s)", tol.TypeName)
+	g.Fpln("type Option func(*%s)", tol.TypeName)
 }
 
-func GenTypeOptionFactories(g *Generator, tol *model.TypeOptionList) {
-	g.P("func With%s(%s %s) Option {", tol.Fields[0].Name, tol.Fields[0].Name, tol.Fields[0].Name)
-	g.Indent()
-	g.P("return func(%s %s) {", "v", tol.Fields[0].Type.TypeString())
-	g.Indent()
+func GenTypeOptionFieldFactories(g *Generator, tol *model.TypeOptionList) {
+	// g.Fpln("func With%s(%s %s) Option {", tol.Fields[0].Name, tol.Fields[0].Name, tol.Fields[0].Name)
+	// g.Indent()
+	// g.Fpln("return func(%s %s) {", "v", tol.Fields[0].Type.TypeString())
+	// g.Indent()
+
+	for _, field := range tol.Fields {
+		GenTypeOptionFieldFactory(g, field)
+		g.Fpln("")
+	}
+}
+
+func GenTypeOptionFieldFactory(g *Generator, field *model.Field) {
+	g.Fpln("func With%s(%s %s) Option {", field.Name, ParamNameFromType(field.Type.TypeString()), field.Name)
 }

--- a/src/gooptions/model/modelprinter/names.go
+++ b/src/gooptions/model/modelprinter/names.go
@@ -1,0 +1,30 @@
+package modelprinter
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+//ParamNameFromType returns a parameter name from a type's name.
+//It returns the lower-cased first rune of typeName.
+//As a special case, if typeName is empty, then this rune value is set to '_'.
+//If this value is equal to typeName, then an underscore is appended to the result.
+//
+//Note that an invalid type name will likely result in an invalid parameter name.
+//
+//TODO something about a qualifier package name.
+func ParamNameFromType(typeName string) string {
+	firstRune, _ := utf8.DecodeRune([]byte(typeName))
+	firstRuneString := string(firstRune)
+
+	if firstRune == utf8.RuneError {
+		firstRuneString = ""
+	}
+
+	result := strings.ToLower(string(firstRuneString))
+	if result == typeName || result == "_" {
+		result += "_"
+	}
+
+	return result
+}

--- a/src/gooptions/model/modelprinter/names_test.go
+++ b/src/gooptions/model/modelprinter/names_test.go
@@ -1,0 +1,40 @@
+package modelprinter_test
+
+import (
+	"testing"
+
+	. "github.com/gogolfing/gooptions/src/gooptions/model/modelprinter"
+)
+
+func TestParamName(t *testing.T) {
+	cases := []struct {
+		typeName string
+		result   string
+	}{
+		{"", "_"},
+		{"_", "__"},
+		{"__", "__"},
+		{"___", "__"},
+		{" ", " _"},
+		{"_x9", "__"},
+		{"\n", "\n_"},
+		{"$", "$_"},
+		{"f", "f_"},
+		{"F", "f"},
+		{"1", "1_"},
+		{"1234", "1"},
+		{"αβ", "α"},
+		{"Ëllo", "ë"},
+		{"foo", "f"},
+		{"Foo", "f"},
+		{"ThisVariableIsExported", "t"},
+	}
+
+	for i, tc := range cases {
+		result := ParamNameFromType(tc.typeName)
+
+		if result != tc.result {
+			t.Errorf("%d: result = %q WANT %q", i, result, tc.result)
+		}
+	}
+}

--- a/src/gooptions/model/modelprinter/printer.go
+++ b/src/gooptions/model/modelprinter/printer.go
@@ -25,7 +25,7 @@ func (p *Printer) Print() error {
 
 	err := p.model.VisitSourceFilePathTypeOptionLists(
 		func(sourceFilePath string, tol *model.TypeOptionList) error {
-			//TODO do some joining out source to output files.
+			//TODO do some joining of source to output files.
 			//TODO do some printing.
 
 			fp := NewFilePrinter(sourceFilePath+"_dest", []*model.TypeOptionList{tol})

--- a/src/gooptions/model/modelprinter/printer.go
+++ b/src/gooptions/model/modelprinter/printer.go
@@ -1,7 +1,7 @@
 package modelprinter
 
 import (
-	"fmt"
+	"log"
 
 	"github.com/gogolfing/gooptions/src/gooptions/model"
 )
@@ -21,7 +21,7 @@ func New(c Config, m *model.Model) *Printer {
 
 //w may be used if there is a sinlge destination package and
 func (p *Printer) Print() error {
-	fmt.Println("printing model")
+	log.Println("Printing model ...")
 
 	err := p.model.VisitSourceFilePathTypeOptionLists(
 		func(sourceFilePath string, tol *model.TypeOptionList) error {


### PR DESCRIPTION
Fixes #1 

This continues with the parsing and generating to get to at least identifier types for generation - these types being the easiest to write, parse, and generate. 